### PR TITLE
Change how outpoint is treated in local storage

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -23,7 +23,4 @@ type Database interface {
 }
 
 // Outpoint represents a Bitcoin transaction output
-type Outpoint struct {
-	TxID  [32]byte
-	Index uint32
-}
+type Outpoint [36]byte

--- a/database/database.go
+++ b/database/database.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+
+	"github.com/shaibearary/utxo_chat/message"
 )
 
 // Database defines the interface for UTXOchat's database operations
@@ -10,17 +12,14 @@ type Database interface {
 	Close() error
 
 	// HasOutpoint checks if an outpoint exists in the database
-	HasOutpoint(ctx context.Context, outpoint Outpoint) (bool, error)
+	HasOutpoint(ctx context.Context, outpoint message.Outpoint) (bool, error)
 
 	// AddOutpoint adds an outpoint to the database
-	AddOutpoint(ctx context.Context, outpoint Outpoint) error
+	AddOutpoint(ctx context.Context, outpoint message.Outpoint) error
 
 	// AddMessage adds a message to the database
-	AddMessage(ctx context.Context, outpoint Outpoint, data []byte) error
+	AddMessage(ctx context.Context, outpoint message.Outpoint, data []byte) error
 
 	// GetMessage retrieves a message from the database by outpoint
-	GetMessage(ctx context.Context, outpoint Outpoint) ([]byte, error)
+	GetMessage(ctx context.Context, outpoint message.Outpoint) ([]byte, error)
 }
-
-// Outpoint represents a Bitcoin transaction output
-type Outpoint [36]byte

--- a/database/memory.go
+++ b/database/memory.go
@@ -2,13 +2,12 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"sync"
 )
 
 // MemoryDB is an in-memory implementation of the Database interface.
 type MemoryDB struct {
-	outpoints map[string]struct{}
+	outpoints map[Outpoint]struct{}
 	mu        sync.RWMutex
 }
 
@@ -25,13 +24,8 @@ func (db *MemoryDB) GetMessage(ctx context.Context, outpoint Outpoint) ([]byte, 
 // NewMemoryDB creates a new in-memory database.
 func NewMemoryDB() *MemoryDB {
 	return &MemoryDB{
-		outpoints: make(map[string]struct{}),
+		outpoints: make(map[Outpoint]struct{}),
 	}
-}
-
-// outpointKey generates a unique key for an outpoint.
-func outpointKey(outpoint Outpoint) string {
-	return fmt.Sprintf("%x:%d", outpoint.TxID, outpoint.Index)
 }
 
 // HasOutpoint checks if the outpoint has been seen before.
@@ -45,7 +39,7 @@ func (db *MemoryDB) HasOutpoint(ctx context.Context, outpoint Outpoint) (bool, e
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
-	_, exists := db.outpoints[outpointKey(outpoint)]
+	_, exists := db.outpoints[outpoint]
 	return exists, nil
 }
 
@@ -60,7 +54,7 @@ func (db *MemoryDB) AddOutpoint(ctx context.Context, outpoint Outpoint) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	db.outpoints[outpointKey(outpoint)] = struct{}{}
+	db.outpoints[outpoint] = struct{}{}
 	return nil
 }
 
@@ -75,7 +69,7 @@ func (db *MemoryDB) RemoveOutpoint(ctx context.Context, outpoint Outpoint) error
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	delete(db.outpoints, outpointKey(outpoint))
+	delete(db.outpoints, outpoint)
 	return nil
 }
 
@@ -91,7 +85,7 @@ func (db *MemoryDB) RemoveOutpoints(ctx context.Context, outpoints []Outpoint) e
 	defer db.mu.Unlock()
 
 	for _, outpoint := range outpoints {
-		delete(db.outpoints, outpointKey(outpoint))
+		delete(db.outpoints, outpoint)
 	}
 	return nil
 }

--- a/database/memory.go
+++ b/database/memory.go
@@ -3,33 +3,38 @@ package database
 import (
 	"context"
 	"sync"
+
+	"github.com/shaibearary/utxo_chat/message"
 )
 
 // MemoryDB is an in-memory implementation of the Database interface.
 type MemoryDB struct {
-	outpoints map[Outpoint]struct{}
+	outpoints map[message.Outpoint]struct{}
 	mu        sync.RWMutex
 }
 
 // AddMessage implements Database.
-func (db *MemoryDB) AddMessage(ctx context.Context, outpoint Outpoint, data []byte) error {
+func (db *MemoryDB) AddMessage(
+	ctx context.Context, outpoint message.Outpoint, data []byte) error {
 	panic("unimplemented")
 }
 
 // GetMessage implements Database.
-func (db *MemoryDB) GetMessage(ctx context.Context, outpoint Outpoint) ([]byte, error) {
+func (db *MemoryDB) GetMessage(
+	ctx context.Context, outpoint message.Outpoint) ([]byte, error) {
 	panic("unimplemented")
 }
 
 // NewMemoryDB creates a new in-memory database.
 func NewMemoryDB() *MemoryDB {
 	return &MemoryDB{
-		outpoints: make(map[Outpoint]struct{}),
+		outpoints: make(map[message.Outpoint]struct{}),
 	}
 }
 
 // HasOutpoint checks if the outpoint has been seen before.
-func (db *MemoryDB) HasOutpoint(ctx context.Context, outpoint Outpoint) (bool, error) {
+func (db *MemoryDB) HasOutpoint(
+	ctx context.Context, outpoint message.Outpoint) (bool, error) {
 	select {
 	case <-ctx.Done():
 		return false, ctx.Err()
@@ -44,7 +49,8 @@ func (db *MemoryDB) HasOutpoint(ctx context.Context, outpoint Outpoint) (bool, e
 }
 
 // AddOutpoint adds an outpoint to the database.
-func (db *MemoryDB) AddOutpoint(ctx context.Context, outpoint Outpoint) error {
+func (db *MemoryDB) AddOutpoint(
+	ctx context.Context, outpoint message.Outpoint) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -59,7 +65,8 @@ func (db *MemoryDB) AddOutpoint(ctx context.Context, outpoint Outpoint) error {
 }
 
 // RemoveOutpoint removes an outpoint from the database.
-func (db *MemoryDB) RemoveOutpoint(ctx context.Context, outpoint Outpoint) error {
+func (db *MemoryDB) RemoveOutpoint(
+	ctx context.Context, outpoint message.Outpoint) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -74,7 +81,8 @@ func (db *MemoryDB) RemoveOutpoint(ctx context.Context, outpoint Outpoint) error
 }
 
 // RemoveOutpoints removes multiple outpoints from the database.
-func (db *MemoryDB) RemoveOutpoints(ctx context.Context, outpoints []Outpoint) error {
+func (db *MemoryDB) RemoveOutpoints(
+	ctx context.Context, outpoints []message.Outpoint) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/shaibearary/utxo_chat/bitcoin"
 	"github.com/shaibearary/utxo_chat/blockchain"
 	"github.com/shaibearary/utxo_chat/database"
-	"github.com/shaibearary/utxo_chat/message"
 	"github.com/shaibearary/utxo_chat/network"
 	"github.com/shaibearary/utxo_chat/utils"
 )
@@ -167,7 +166,7 @@ func utxoChatMain() error {
 	}
 
 	// Initialize message validator.
-	validator := message.NewValidator(bitcoinClient, db)
+	validator := database.NewValidator(bitcoinClient, db)
 
 	// Initialize P2P network.
 	networkCfg := network.Config{


### PR DESCRIPTION
Starting with a simple PR to change how outpoints are treated.  This doesn't really change much, and is definitely a preference thing so I'm fine if the PR is closed and it stays as the txid : index format.

My reasoning here is that in utxo chat, the outpoints basically become the unique identifiers for messages the way txids are in bitcoin.  The fact that there are actually 2 components to the outpoints is probably never used (that I can think of).  It would actually be nicer if we could store outpoint hashes just so it's not a weird number of bytes, but the one thing we *do* need to do with the outpoints is ask about them to bitcoind over the `gettxout` RPC, and that requires the whole thing.  Since in that case we're converting to JSON anyway, it seems just as easy to keep it as a 36 byte array.

Not nearly as important, but I guess it would take up less memory (since not converting to ascii hex), and maybe be a bit faster.  But that would only matter with millions of entries :)
